### PR TITLE
feat(sugar-scripts): 支持 Rspack 作为可选构建工具

### DIFF
--- a/packages/sugar-scripts/package.json
+++ b/packages/sugar-scripts/package.json
@@ -34,11 +34,25 @@
     "webpack-manifest-plugin": "^5.0.0"
   },
   "devDependencies": {
+    "@rspack/core": "^1.0.0",
     "@types/glob": "~7.2.0",
     "@types/node": "^18.0.0",
     "@types/nodemon": "^1.19.2",
     "@types/webpack": "^5",
     "rimraf": "^3.0.2",
+    "rspack-chain": "^1.0.0",
     "typescript": "^4.3.5"
+  },
+  "peerDependencies": {
+    "@rspack/core": "^1.0.0",
+    "rspack-chain": "^1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    },
+    "rspack-chain": {
+      "optional": true
+    }
   }
 }

--- a/packages/sugar-scripts/src/core/build.ts
+++ b/packages/sugar-scripts/src/core/build.ts
@@ -44,14 +44,19 @@ export const build = async (
 const buildBrowser = async (context: SugarScriptsContext) => {
   if (!context.packageConfig.browser) return;
   const browserConfig = context.packageConfig.browser;
+  const bundler = context.packageConfig.bundler || 'webpack';
 
-  logger.info('build browser');
+  logger.info(`build browser [${bundler}]`);
   logger.log(JSON.stringify(browserConfig));
 
-  const chainConfig = await createCommonChainConfig(
-    context,
-    browserConfig.output
-  );
+  let chainConfig: any;
+
+  if (bundler === 'rspack') {
+    const { createCommonRspackChainConfig } = await import('../webpack/rspack.common');
+    chainConfig = await createCommonRspackChainConfig(context, browserConfig.output);
+  } else {
+    chainConfig = await createCommonChainConfig(context, browserConfig.output);
+  }
 
   await mergeBrowserEntry(
     context,
@@ -63,10 +68,19 @@ const buildBrowser = async (context: SugarScriptsContext) => {
     chainConfig
   )
 
-  if (context.watch) {
-    await runWatchWebpack(chainConfig);
+  if (bundler === 'rspack') {
+    const { runRspack, runWatchRspack } = await import('../webpack/run-rspack');
+    if (context.watch) {
+      await runWatchRspack(chainConfig.toConfig());
+    } else {
+      await runRspack(chainConfig.toConfig());
+    }
   } else {
-    await runWebpack(chainConfig);
+    if (context.watch) {
+      await runWatchWebpack(chainConfig);
+    } else {
+      await runWebpack(chainConfig);
+    }
   }
 
   logger.success('build browser finish');
@@ -76,14 +90,19 @@ const buildBrowser = async (context: SugarScriptsContext) => {
 const buildServer = async (context: SugarScriptsContext) => {
   if (!context.packageConfig.server) return;
   const serverConfig = context.packageConfig.server;
+  const bundler = context.packageConfig.bundler || 'webpack';
 
-  logger.info('build server');
+  logger.info(`build server [${bundler}]`);
   logger.log(JSON.stringify(serverConfig));
 
-  const chainConfig = await createCommonChainConfig(
-    context,
-    serverConfig.output
-  );
+  let chainConfig: any;
+
+  if (bundler === 'rspack') {
+    const { createCommonRspackChainConfig } = await import('../webpack/rspack.common');
+    chainConfig = await createCommonRspackChainConfig(context, serverConfig.output);
+  } else {
+    chainConfig = await createCommonChainConfig(context, serverConfig.output);
+  }
 
   await mergeServerEntry(
     context,
@@ -94,10 +113,19 @@ const buildServer = async (context: SugarScriptsContext) => {
     chainConfig
   );
 
-  if (context.watch) {
-    await runWatchWebpack(chainConfig);
+  if (bundler === 'rspack') {
+    const { runRspack, runWatchRspack } = await import('../webpack/run-rspack');
+    if (context.watch) {
+      await runWatchRspack(chainConfig.toConfig());
+    } else {
+      await runRspack(chainConfig.toConfig());
+    }
   } else {
-    await runWebpack(chainConfig);
+    if (context.watch) {
+      await runWatchWebpack(chainConfig);
+    } else {
+      await runWebpack(chainConfig);
+    }
   }
 
   logger.success('build server finish');

--- a/packages/sugar-scripts/src/custom-config.type.ts
+++ b/packages/sugar-scripts/src/custom-config.type.ts
@@ -22,6 +22,11 @@ export namespace SugarScriptsProject {
      */
     cacheDir?: string;
     /**
+     * 构建工具选择
+     * @default 'webpack'
+     */
+    bundler?: 'webpack' | 'rspack';
+    /**
      * 浏览器端js输出目录，不配置就不会进行相关打包
      */
     browser?: {

--- a/packages/sugar-scripts/src/webpack/rspack.common.ts
+++ b/packages/sugar-scripts/src/webpack/rspack.common.ts
@@ -1,0 +1,83 @@
+import path from 'path';
+import { rspack } from '@rspack/core';
+import RspackChain from 'rspack-chain';
+
+import {
+  SugarScriptsContext
+} from '../core/running-context';
+
+export async function createCommonRspackChainConfig(
+  context: SugarScriptsContext,
+  output: string
+): Promise<RspackChain> {
+  const mode = process.env.WEBPACK_MODE === 'development' ? 'development' : 'production';
+
+  let chainConfig = new RspackChain();
+
+  chainConfig.merge({
+    context: context.root,
+    resolve: {
+      extensions: [
+        '.ts',
+        '.tsx',
+        '.js',
+        '.jsx'
+      ],
+    },
+    output: {
+      path: path.resolve(
+        context.root,
+        output || 'dist'
+      ),
+      filename:
+        mode === 'development'
+          ? '[name].js'
+          : '[name].[contenthash].js'
+    },
+    mode,
+    devtool: mode === 'development' ? 'source-map' : false,
+    optimization: {
+      moduleIds: 'named',
+      chunkIds: 'named'
+    },
+    stats: {
+      all: true,
+      errorDetails: true
+    },
+    module: {
+      rule: {
+        script: {
+          test: /\.(ts|tsx|js|jsx)$/,
+          use: {
+            'swc-loader': {
+              loader: 'builtin:swc-loader',
+              options: {
+                jsc: {
+                  parser: {
+                    syntax: 'typescript',
+                    tsx: true,
+                    decorators: true,
+                  },
+                  transform: {
+                    react: {
+                      runtime: 'classic',
+                    },
+                  },
+                  externalHelpers: true,
+                },
+              }
+            }
+          }
+        }
+      },
+    },
+    plugin: {
+      'ProgressPlugin': {
+        plugin: rspack.ProgressPlugin,
+        args: []
+      }
+    }
+  });
+
+  return chainConfig;
+}

--- a/packages/sugar-scripts/src/webpack/run-rspack.ts
+++ b/packages/sugar-scripts/src/webpack/run-rspack.ts
@@ -1,0 +1,40 @@
+import { rspack } from '@rspack/core';
+import type { RspackOptions } from '@rspack/core';
+
+import * as logger from '../shared/logger';
+
+export const runRspack = (
+  config: RspackOptions
+) => {
+  const compiler = rspack(config);
+
+  return new Promise((resolve, reject) => {
+    compiler.run((err, stats) => {
+      if (err || stats && stats.hasErrors()) {
+        reject(err || stats?.toString());
+        logger.error(stats?.toString() || '');
+        return;
+      }
+      logger.log(stats?.toString() || '');
+      resolve(stats);
+    });
+  });
+};
+
+export const runWatchRspack = (
+  config: RspackOptions
+) => {
+  const compiler = rspack(config);
+
+  return new Promise((resolve, reject) => {
+    compiler.watch({}, (err, stats) => {
+      if (err || stats && stats.hasErrors()) {
+        reject(err || stats?.toString());
+        logger.error(stats?.toString() || '');
+        return;
+      }
+      logger.log(stats?.toString() || '');
+      resolve(stats);
+    });
+  });
+};


### PR DESCRIPTION
在 PackageConfig 中新增 bundler 字段，允许项目选择使用 webpack 或 rspack 进行构建。 rspack 模块通过动态 import 加载，不影响现有 webpack 用户。